### PR TITLE
add feature 'unix shortcuts' into evolution

### DIFF
--- a/zshclock.zsh
+++ b/zshclock.zsh
@@ -57,17 +57,17 @@ function ztc:build { # set view area + build components
     ztc[vh]=$LINES
     ztc[vw]=$COLUMNS
 
-    local _components=()
-    ztc:steal components _components
+    local _ztcb_components=()
+    ztc:steal components _ztcb_components
 
-    for _name in $_components; do "ztc:order:$_name"; done
+    for _ztcb_name in $_ztcb_components; do "ztc:order:$_ztcb_name"; done
 
     ztc:cycle
 }
 
 function ztc:drive { # clock go vroom vroom
-    float _epoch=$EPOCHREALTIME
-    integer _epsilon=0
+    float _ztcd_epoch=$EPOCHREALTIME
+    integer _ztcd_epsilon=0
 
     while true; do
         ztc:input # handle inputs
@@ -77,25 +77,25 @@ function ztc:drive { # clock go vroom vroom
         if [[ ztc[commander:status] != '' && ${$(( (EPOCHREALTIME - ztc[commander:epoch]) * 1000 ))%%.*} -gt ztc[:rate:status] ]]; then ztc:commander:clear; fi
 
         # repaint clock
-        integer _duration=${$(( (EPOCHREALTIME - _epoch) * 1000 ))%%.*}
-        if (( _duration >= ( ztc[:rate:refresh] - _epsilon ) )); then
+        integer _ztcd_duration=${$(( (EPOCHREALTIME - _ztcd_epoch) * 1000 ))%%.*}
+        if (( _ztcd_duration >= ( ztc[:rate:refresh] - _ztcd_epsilon ) )); then
 
             ztc:cycle # update component data + repaint
 
-            _epoch=$EPOCHREALTIME
-            _epsilon=$(( ( _duration - (ztc[:rate:refresh] - _epsilon) ) % ztc[:rate:refresh] ))
+            _ztcd_epoch=$EPOCHREALTIME
+            _ztcd_epsilon=$(( ( _ztcd_duration - (ztc[:rate:refresh] - _ztcd_epsilon) ) % ztc[:rate:refresh] ))
 
         fi
     done
 }
 
 function ztc:clean { # dissolve clock + restore terminal state
-    integer _code=${1:-0}
+    integer _ztcc_code=${1:-0}
     ztc:write $ZTC_CURSOR_SHOW $ZTC_EXIT
 
     stty dsusp '^Y' # restore delayed suspend
 
-    exit $_code
+    exit $_ztcc_code
 }
 
 
@@ -115,24 +115,24 @@ function ztc:plonk { # set config settings + register parts
 
     # ───── register flares ─────
 
-    local -U _flares=(newline reset bold invert)
-    local -A _guide=()
+    local -U _ztcpl_flares=(newline reset bold invert)
+    local -A _ztcpl_guide=()
 
     # ╶╶╶╶╶ generate short flares ╴╴╴╴╴
 
-    local -A _route=()
+    local -A _ztcpl_route=()
 
-    for _i in {1..${#_flares}}; do
-        local _length=${#_flares[$_i]}
-        _route[$_length]="$_route[$_length]@$_flares[$_i]"
+    for _ztcpl_i in {1..${#_ztcpl_flares}}; do
+        local _ztcpl_length=${#_ztcpl_flares[$_ztcpl_i]}
+        _ztcpl_route[$_ztcpl_length]="$_ztcpl_route[$_ztcpl_length]@$_ztcpl_flares[$_ztcpl_i]"
 
-        for _j in {1..$_length}; do
-            local _abbr=${_flares[$_i]:0:$_j}
+        for _ztcpl_j in {1..$_ztcpl_length}; do
+            local _ztcpl_abbr=${_ztcpl_flares[$_ztcpl_i]:0:$_ztcpl_j}
 
-            if (( ! _flares[(Ie)$_abbr] )); then
-                _flares+=($_abbr)
-                _guide[$_abbr]=$_flares[$_i]
-                _route[$_j]="$_route[$_j]@$_abbr"
+            if (( ! _ztcpl_flares[(Ie)$_ztcpl_abbr] )); then
+                _ztcpl_flares+=($_ztcpl_abbr)
+                _ztcpl_guide[$_ztcpl_abbr]=$_ztcpl_flares[$_ztcpl_i]
+                _ztcpl_route[$_ztcpl_j]="$_ztcpl_route[$_ztcpl_j]@$_ztcpl_abbr"
                 break
             fi
         done
@@ -140,29 +140,29 @@ function ztc:plonk { # set config settings + register parts
 
     # ╶╶╶╶╶ flatten guide ╴╴╴╴╴
 
-    local -U _flat=()
-    for _key _value in ${(kv)_guide}; do _flat+=("$_key#$_value"); done
+    local -U _ztcpl_flat=()
+    for _ztcpl_key _ztcpl_value in ${(kv)_ztcpl_guide}; do _ztcpl_flat+=("$_ztcpl_key#$_ztcpl_value"); done
 
-    ztc:stash flares:guide _flat
+    ztc:stash flares:guide _ztcpl_flat
 
     # ╶╶╶╶╶ rebuild flare array + sort descending ╴╴╴╴╴
 
-    _flares=()
-    for _key in ${(Ok)_route}; do _flares+=(${(As:@:)_route[$_key]}); done
+    _ztcpl_flares=()
+    for _ztcpl_key in ${(Ok)_ztcpl_route}; do _ztcpl_flares+=(${(As:@:)_ztcpl_route[$_ztcpl_key]}); done
 
-    ztc:stash flares _flares
+    ztc:stash flares _ztcpl_flares
 
 
     # ───── register commands ─────
 
-    local -U _commands=(date)
-    ztc:stash :commands _commands
+    local -U _ztcpl_commands=(date)
+    ztc:stash :commands _ztcpl_commands
 
 
     # ───── register components ─────
 
-    local -U _components=(face:digital date commander)
-    ztc:stash components _components
+    local -U _ztcpl_components=(face:digital date commander)
+    ztc:stash components _ztcpl_components
 
 }
 
@@ -171,7 +171,9 @@ function ztc:plonk { # set config settings + register parts
 # │ ░░▒▒▓▓██  CASSETTES  ██▓▓▒▒░░ │
 # └───────────────────────────────┘
 
-# ───── ztc ─────
+# ┌───────────┐
+# │    ztc    │
+# └───────────┘
 
 function ztc:align { # check for resizes + rebuild
     LINES=
@@ -190,7 +192,9 @@ function ztc:cycle { # update component data + repaint
 }
 
 
-# ───── commander ─────
+# ┌─────────────────┐
+# │    commander    │
+# └─────────────────┘
 
 function ztc:commander:enter {
     ztc[commander:active]=1
@@ -213,6 +217,22 @@ function ztc:commander:clear {
     ztc:cycle commander
 }
 
+function ztc:commander:shift {
+    local _ztccs_in=${(P)1}
+    local _ztccs_i=${(P)2}
+
+    local _ztccs_l=''
+    local _ztccs_r=''
+    local _ztccs_lw=''
+    local _ztccs_rw=''
+
+    ztc:words _ztccs_in _ztccs_i both _ztccs_l _ztccs_r _ztccs_lw _ztccs_rw
+    ztc:shift _ztccs_in _ztccs_i $3 _ztccs_l _ztccs_r _ztccs_lw _ztccs_rw
+
+    ztc[commander:input]=$_ztccs_in
+    ztc[commander:cursor]=${#_ztccs_r}
+}
+
 
 # ┌─────────────────────────────┐
 # │ ░░▒▒▓▓██  ENGINES  ██▓▓▒▒░░ │
@@ -224,10 +244,10 @@ function ztc:commander:clear {
 
 function ztc:paint { # translate component data for rendering
 
-    local -U _components=()
-    ztc:steal components _components
+    local -U _ztcp_components=()
+    ztc:steal components _ztcp_components
 
-    local -U _touch=(${@:-$_components})
+    local -U _ztcp_touch=(${@:-$_ztcp_components})
 
 
     # ───── reset bounds ─────
@@ -243,107 +263,107 @@ function ztc:paint { # translate component data for rendering
 
     # ───── get component properties + cache ─────
 
-    for _name in $_components; do
+    for _ztcp_name in $_ztcp_components; do
 
-        integer _y=0
-        integer _x=0
-        integer _h=0
-        integer _w=0
+        integer _ztcp_y=0
+        integer _ztcp_x=0
+        integer _ztcp_h=0
+        integer _ztcp_w=0
 
-        if (( _touch[(Ie)$_name] )); then # flare data + calculate dimensions
+        if (( _ztcp_touch[(Ie)$_ztcp_name] )); then # flare data + calculate dimensions
 
-            local _data=()
-            ztc:steal ${_name}:data _data
+            local _ztcp_data=()
+            ztc:steal ${_ztcp_name}:data _ztcp_data
 
             # ╶╶╶╶╶ translate data mask ╴╴╴╴╴
 
-            if [[ $ztc[${_name}:data:format] == 'masked' ]]; then
-                local -U _key=()
-                ztc:steal ${_name}:data:key _key
+            if [[ $ztc[${_ztcp_name}:data:format] == 'masked' ]]; then
+                local -U _ztcp_key=()
+                ztc:steal ${_ztcp_name}:data:key _ztcp_key
 
-                for _k in $_key; do
-                    local _entry=(${(As:#:)_k})
-                    for _i in {1..${#_data}}; do _data[$_i]=${_data[$_i]//$_entry[1]/$_entry[2]}; done
+                for _ztcp_k in $_ztcp_key; do
+                    local _ztcp_entry=(${(As:#:)_ztcp_k})
+                    for _ztcp_i in {1..${#_ztcp_data}}; do _ztcp_data[$_ztcp_i]=${_ztcp_data[$_ztcp_i]//$_ztcp_entry[1]/$_ztcp_entry[2]}; done
                 done
             fi
 
-            local _flared=()
-            ztc:flare _data _flared
+            local _ztcp_flared=()
+            ztc:flare _ztcp_data _ztcp_flared
 
             # ╶╶╶╶╶ component height ╴╴╴╴╴
 
-            case $ztc[${_name}:h] in
+            case $ztc[${_ztcp_name}:h] in
                 (:auto) # set height to number of lines
-                    _h=${#_flared} ;;
+                    _ztcp_h=${#_ztcp_flared} ;;
                 (*)
-                    _h=$ztc[${_name}:h] ;;
+                    _ztcp_h=$ztc[${_ztcp_name}:h] ;;
             esac
 
             # ╶╶╶╶╶ component width ╴╴╴╴╴
 
-            case $ztc[${_name}:w] in
+            case $ztc[${_ztcp_name}:w] in
                 (:auto) # set width to length of longest line
-                    local _length=0
+                    local _ztcp_length=0
 
-                    for _line in $_flared; do # strip escapes
-                        _line=${_line//@\(@\)/@}
-                        _line=${(S)_line//${ZTC_CSI}*(m|H|K|J|A|B|C|D|E|F|G|S|T|f|i|n|h|l|s|u)}
+                    for _ztcp_line in $_ztcp_flared; do # strip escapes
+                        _ztcp_line=${_ztcp_line//@\(@\)/@}
+                        _ztcp_line=${(S)_ztcp_line//${ZTC_CSI}*(m|H|K|J|A|B|C|D|E|F|G|S|T|f|i|n|h|l|s|u)}
 
-                        if (( ${#_line} > _length )); then _length=${#_line}; fi
+                        if (( ${#_ztcp_line} > _ztcp_length )); then _ztcp_length=${#_ztcp_line}; fi
                     done
 
-                    _w=$_length
+                    _ztcp_w=$_ztcp_length
                     ;;
                 (*)
-                    _w=$ztc[${_name}:w]
+                    _ztcp_w=$ztc[${_ztcp_name}:w]
                     ;;
             esac
 
             # ╶╶╶╶╶ component y-origin ╴╴╴╴╴
 
-            case $ztc[${_name}:y] in
+            case $ztc[${_ztcp_name}:y] in
                 (:auto) # center component vertically
-                    _y=$(( ( (ztc[vh] - _h) / 2 ) + 1 )) ;;
+                    _ztcp_y=$(( ( (ztc[vh] - _ztcp_h) / 2 ) + 1 )) ;;
                 (*)
-                    _y=$ztc[${_name}:y] ;;
+                    _ztcp_y=$ztc[${_ztcp_name}:y] ;;
             esac
 
             # ╶╶╶╶╶ component x-origin ╴╴╴╴╴
 
-            case $ztc[${_name}:x] in
+            case $ztc[${_ztcp_name}:x] in
                 (:auto) # center component horizontally
-                    _x=$(( ( (ztc[vw] - _w) / 2 ) + 1 )) ;;
+                    _ztcp_x=$(( ( (ztc[vw] - _ztcp_w) / 2 ) + 1 )) ;;
                 (*)
-                    _x=$ztc[${_name}:x] ;;
+                    _ztcp_x=$ztc[${_ztcp_name}:x] ;;
             esac
 
             # ╶╶╶╶╶ save/cache calculations ╴╴╴╴╴
 
-            ztc[paint:${_name}:h]=$_h
-            ztc[paint:${_name}:w]=$_w
-            ztc[paint:${_name}:y]=$_y
-            ztc[paint:${_name}:x]=$_x
+            ztc[paint:${_ztcp_name}:h]=$_ztcp_h
+            ztc[paint:${_ztcp_name}:w]=$_ztcp_w
+            ztc[paint:${_ztcp_name}:y]=$_ztcp_y
+            ztc[paint:${_ztcp_name}:x]=$_ztcp_x
 
-            ztc:stash paint:${_name}:data _flared
+            ztc:stash paint:${_ztcp_name}:data _ztcp_flared
 
         else # retrieve from cache
 
-            _h=$ztc[paint:${_name}:h]
-            _w=$ztc[paint:${_name}:w]
-            _y=$ztc[paint:${_name}:y]
-            _x=$ztc[paint:${_name}:x]
+            _ztcp_h=$ztc[paint:${_ztcp_name}:h]
+            _ztcp_w=$ztc[paint:${_ztcp_name}:w]
+            _ztcp_y=$ztc[paint:${_ztcp_name}:y]
+            _ztcp_x=$ztc[paint:${_ztcp_name}:x]
 
         fi
 
         # ╶╶╶╶╶ update bounds ╴╴╴╴╴
 
-        if (( ! ztc[${_name}:overlay] )); then
-            (( ztc[paint:h] += $_h )) # only for layout:vertical when position:auto
+        if (( ! ztc[${_ztcp_name}:overlay] )); then
+            (( ztc[paint:h] += $_ztcp_h )) # only for layout:vertical when position:auto
 
-            if (( _y + _h > ztc[paint:ym] )); then ztc[paint:ym]=$((_y + _h)); fi
-            if (( _x + _w > ztc[paint:xm] )); then ztc[paint:xm]=$((_x + _w)); fi
-            if      (( _y < ztc[paint:my] )); then ztc[paint:my]=$_y; fi
-            if      (( _x < ztc[paint:mx] )); then ztc[paint:mx]=$_x; fi
+            if (( _ztcp_y + _ztcp_h > ztc[paint:ym] )); then ztc[paint:ym]=$((_ztcp_y + _ztcp_h)); fi
+            if (( _ztcp_x + _ztcp_w > ztc[paint:xm] )); then ztc[paint:xm]=$((_ztcp_x + _ztcp_w)); fi
+            if (( _ztcp_y < ztc[paint:my] )); then ztc[paint:my]=$_ztcp_y; fi
+            if (( _ztcp_x < ztc[paint:mx] )); then ztc[paint:mx]=$_ztcp_x; fi
         fi
     done
 
@@ -354,32 +374,32 @@ function ztc:paint { # translate component data for rendering
     ztc[paint:w]=$(( ztc[paint:xm] - ztc[paint:mx] ))
     ztc[paint:my]=$(( ( (ztc[vh] - ztc[paint:h]) / 2 ) + 1 )) # override h for position:auto
 
-    integer _dy=0
+    integer _ztcp_dy=0
 
-    for _name in $_components; do
-        if (( ! ztc[${_name}:overlay] )); then
-            ztc[paint:${_name}:y]=$(( ztc[paint:my] + _dy ))
-            (( _dy += ztc[paint:${_name}:h] ))
+    for _ztcp_name in $_ztcp_components; do
+        if (( ! ztc[${_ztcp_name}:overlay] )); then
+            ztc[paint:${_ztcp_name}:y]=$(( ztc[paint:my] + _ztcp_dy ))
+            (( _ztcp_dy += ztc[paint:${_ztcp_name}:h] ))
         fi
     done
 
 
     # ───── paint component data ─────
 
-    local _staged=()
+    local _ztcp_staged=()
 
-    for _name in $_components; do
-        local _matter=${ztc[paint:${_name}:data]//@@/@\(@\)}
-        local _origin="${ZTC_CSI}${ztc[paint:${_name}:y]};${ztc[paint:${_name}:x]}H"
+    for _ztcp_name in $_ztcp_components; do
+        local _ztcp_matter=${ztc[paint:${_ztcp_name}:data]//@@/@\(@\)}
+        local _ztcp_origin="${ZTC_CSI}${ztc[paint:${_ztcp_name}:y]};${ztc[paint:${_ztcp_name}:x]}H"
 
-        _matter=${_matter//@n/${ZTC_CSI}E${ZTC_CSI}$(( ztc[paint:${_name}:x] - 1 ))C}
-        _staged+=($_origin ${_matter//@\(@\)/@} $ZTC_TEXT_RESET)
+        _ztcp_matter=${_ztcp_matter//@n/${ZTC_CSI}E${ZTC_CSI}$(( ztc[paint:${_ztcp_name}:x] - 1 ))C}
+        _ztcp_staged+=($_ztcp_origin ${_ztcp_matter//@\(@\)/@} $ZTC_TEXT_RESET)
     done
 
 
     # ───── render ─────
 
-    ztc:write $ZTC_CLEAR ${(j::)_staged}
+    ztc:write $ZTC_CLEAR ${(j::)_ztcp_staged}
 
 }
 
@@ -391,47 +411,47 @@ function ztc:flare { # expand `@` flares + calc width
 
     # ───── import + setup ─────
 
-    local _input=${(Pj:@n:)1//@@/@\(@\)} # escape `@@`
+    local _ztcf_input=${(Pj:@n:)1//@@/@\(@\)} # escape `@@`
 
-    local _flares=()
-    ztc:steal flares _flares
+    local _ztcf_flares=()
+    ztc:steal flares _ztcf_flares
 
     # ╶╶╶╶╶ retrieve guide ╴╴╴╴╴
 
-    local -U _flat=()
-    local -A _guide=()
-    ztc:steal flares:guide _flat
+    local -U _ztcf_flat=()
+    local -A _ztcf_guide=()
+    ztc:steal flares:guide _ztcf_flat
 
-    for _item in $_flat; do
-        local -U _entry=(${(As:#:)_item})
-        _guide[$_entry[1]]=$_entry[2]
+    for _ztcf_item in $_ztcf_flat; do
+        local -U _ztcf_entry=(${(As:#:)_ztcf_item})
+        _ztcf_guide[$_ztcf_entry[1]]=$_ztcf_entry[2]
     done
 
 
     # ───── delegate flare to correct expander ─────
 
-    for _flare in $_flares; do
+    for _ztcf_flare in $_ztcf_flares; do
 
         # ╶╶╶╶╶ skip flaring if out of flares ╴╴╴╴╴
 
-        if [[ ! $_input =~ @ ]]; then break; fi
+        if [[ ! $_ztcf_input =~ @ ]]; then break; fi
 
         # ╶╶╶╶╶ link alias ╴╴╴╴╴
 
-        local _alias=$_flare
-        if (( ${${(k)_guide}[(Ie)$_flare]} )); then _alias=$_guide[$_flare]; fi
+        local _ztcf_alias=$_ztcf_flare
+        if (( ${${(k)_ztcf_guide}[(Ie)$_ztcf_flare]} )); then _ztcf_alias=$_ztcf_guide[$_ztcf_flare]; fi
 
         # ╶╶╶╶╶ wrap flare + expand ╴╴╴╴╴
 
-        _input=${_input//@$_flare/@\($_flare\)}
-        ztc:flare:$_alias _input $_flare
+        _ztcf_input=${_ztcf_input//@$_ztcf_flare/@\($_ztcf_flare\)}
+        ztc:flare:$_ztcf_alias _ztcf_input $_ztcf_flare
 
     done
 
 
     # ───── export ─────
 
-    : ${(AP)2::=${(s:@n:)_input}}
+    : ${(AP)2::=${(s:@n:)_ztcf_input}}
 
 }
 
@@ -449,19 +469,19 @@ function ztc:input { # detect user inputs + build commands
 
     # ───── read input ─────
 
-    local _key=''
-    read -s -t $(( ztc[:rate:input] / 1000.0 )) -k 1 _key
+    local _ztci_key=''
+    read -s -t $(( ztc[:rate:input] / 1000.0 )) -k 1 _ztci_key
 
 
     # ───── process input ─────
 
     if (( ztc[commander:active] )); then # attach input to command bar
 
-        local _input=$ztc[commander:input]
-        integer _cursor=$ztc[commander:cursor]
-        integer _index=$(( ${#_input} - _cursor ))
+        local _ztci_input=$ztc[commander:input]
+        integer _ztci_cursor=$ztc[commander:cursor]
+        integer _ztci_index=$(( ${#_ztci_input} - _ztci_cursor ))
 
-        case $_key in
+        case $_ztci_key in
 
             # ╶╶╶╶╶ ignore empty keys ╴╴╴╴╴
 
@@ -470,146 +490,123 @@ function ztc:input { # detect user inputs + build commands
             # ╶╶╶╶╶ <esc> + special keys ╴╴╴╴╴
 
             ($'\e')
-                local _s1=''
-                local _s2=''
-                local _s3=''
-                local _s4=''
-                local _s5=''
+                local _ztci_s1=''
+                local _ztci_s2=''
+                local _ztci_s3=''
+                local _ztci_s4=''
+                local _ztci_s5=''
 
-                read -st -k 1 _s1
-                read -st -k 1 _s2
-                read -st -k 1 _s3
-                read -st -k 1 _s4
-                read -st -k 1 _s5
+                read -st -k 1 _ztci_s1
+                read -st -k 1 _ztci_s2
+                read -st -k 1 _ztci_s3
+                read -st -k 1 _ztci_s4
+                read -st -k 1 _ztci_s5
 
-                local _special=$_s1$_s2$_s3$_s4$_s5
+                local _ztci_special=$_ztci_s1$_ztci_s2$_ztci_s3$_ztci_s4$_ztci_s5
 
-                case $_special in
+                case $_ztci_special in
 
                     # ╶╶╶╶╶ <esc> ╴╴╴╴╴
 
                     ('') ztc:commander:leave ;;
 
-                    # ╶╶╶╶╶ <up> ╴╴╴╴╴
+                    # ╶╶╶╶╶ <up> (previous line in history) ╴╴╴╴╴
 
-                    ('[A') ;;
+                    ('[A')
+                        integer _ztci_hindex=$ztc[commander:history:index]
+                        local _ztci_history=()
+                        ztc:steal commander:history _ztci_history
 
-                    # ╶╶╶╶╶ <down> ╴╴╴╴╴
+                        if (( ${#_ztci_history} > 0 && _ztci_hindex < ${#_ztci_history} )); then
+                            (( _ztci_hindex++ ))
+                            ztc[commander:input]=$_ztci_history[$(( ${#_ztci_history} - _ztci_hindex + 1 ))]
+                            ztc[commander:history:index]=$_ztci_hindex
+                        fi
+                        ;;
 
-                    ('[B') ;;
+                    # ╶╶╶╶╶ <down> (next line in history) ╴╴╴╴╴
+
+                    ('[B')
+                        integer _ztci_hindex=$ztc[commander:history:index]
+                        local _ztci_history=()
+                        ztc:steal commander:history _ztci_history
+
+                        if (( ${#_ztci_history} > 0 && _ztci_hindex > 0 )); then
+                            (( _ztci_hindex-- ))
+                            if (( _ztci_hindex == 0 )); then ztc[commander:input]=''
+                            else ztc[commander:input]=$_ztci_history[$(( ${#_ztci_history} - _ztci_hindex + 1 ))]; fi
+                            ztc[commander:history:index]=$_ztci_hindex
+                        fi
+                        ;;
 
                     # ╶╶╶╶╶ <right> (move cursor right) ╴╴╴╴╴
 
-                    ('[C') if (( _cursor > 0 )); then (( ztc[commander:cursor]-- )); fi ;;
+                    ('[C') if (( _ztci_cursor > 0 )); then (( ztc[commander:cursor]-- )); fi ;;
 
                     # ╶╶╶╶╶ <left> (move cursor left) ╴╴╴╴╴
 
-                    ('[D') if (( _index > 0 )); then (( ztc[commander:cursor]++ )); fi ;;
+                    ('[D') if (( _ztci_index > 0 )); then (( ztc[commander:cursor]++ )); fi ;;
 
                     # ╶╶╶╶╶ <alt-delete> (delete word) ╴╴╴╴╴
 
                     ($'\x7f')
-                        if (( _index != 0 )); then
-                            local _left=''
-                            local _word=''
-                            ztc:words _input _index left _left _word
+                        if (( _ztci_index != 0 )); then
+                            local _ztci_left=''
+                            local _ztci_word=''
+                            ztc:words _ztci_input _ztci_index left _ztci_left _ztci_word
 
-                            ztc[commander:yank]=$_word
-                            ztc[commander:input]=$_left${_input:_index}
+                            ztc[commander:yank]=$_ztci_word
+                            ztc[commander:input]=$_ztci_left${_ztci_input:_ztci_index}
                         fi ;;
 
                     # ╶╶╶╶╶ <alt-b>/<alt-left> (move cursor one word left) ╴╴╴╴╴
 
                     ('b'|'[1;3D')
-                        if (( _index != 0 )); then
-                            local _left=''
-                            ztc:words _input _index left _left
+                        if (( _ztci_index != 0 )); then
+                            local _ztci_left=''
+                            ztc:words _ztci_input _ztci_index left _ztci_left
 
-                            ztc[commander:cursor]=$(( ${#_input} - ${#_left} ))
+                            ztc[commander:cursor]=$(( ${#_ztci_input} - ${#_ztci_left} ))
                         fi ;;
 
                     # ╶╶╶╶╶ <alt-c> (capitalize word) ╴╴╴╴╴
 
-                    ('c')
-                        local _left=''
-                        local _right=''
-                        local _lword=''
-                        local _rword=''
-
-                        ztc:words _input _index both _left _right _lword _rword
-                        ztc:shift _input _index C _left _right _lword _rword
-
-                        ztc[commander:input]=$_input
-                        ztc[commander:cursor]=${#_right}
-                        ;;
+                    ('c') ztc:commander:shift _ztci_input _ztci_index C ;;
 
                     # ╶╶╶╶╶ <alt-d> (forward delete word) ╴╴╴╴╴
 
                     ('d')
-                        if (( _cursor != 0 )); then
-                            local _right=''
-                            local _word=''
-                            ztc:words _input _index right _right _word
+                        if (( _ztci_cursor != 0 )); then
+                            local _ztci_right=''
+                            local _ztci_word=''
+                            ztc:words _ztci_input _ztci_index right _ztci_right _ztci_word
 
-                            ztc[commander:yank]=$_word
-                            ztc[commander:input]=${_input:0:_index}$_right
-                            ztc[commander:cursor]=${#_right}
+                            ztc[commander:yank]=$_ztci_word
+                            ztc[commander:input]=${_ztci_input:0:_ztci_index}$_ztci_right
+                            ztc[commander:cursor]=${#_ztci_right}
                         fi ;;
 
                     # ╶╶╶╶╶ <alt-f>/<alt-right> (move cursor one word right) ╴╴╴╴╴
 
                     ('f'|'[1;3C')
-                        if (( _cursor != 0 )); then
-                            local right=''
-                            ztc:words _input _index right _right
+                        if (( _ztci_cursor != 0 )); then
+                            local ztci_right=''
+                            ztc:words _ztci_input _ztci_index right _ztci_right
 
-                            ztc[commander:cursor]=${#_right}
+                            ztc[commander:cursor]=${#_ztci_right}
                         fi ;;
 
                     # ╶╶╶╶╶ <alt-l> (lowercase word) ╴╴╴╴╴
 
-                    ('l')
-                        local _left=''
-                        local _right=''
-                        local _lword=''
-                        local _rword=''
-
-                        ztc:words _input _index both _left _right _lword _rword
-                        ztc:shift _input _index L _left _right _lword _rword
-
-                        ztc[commander:input]=$_input
-                        ztc[commander:cursor]=${#_right}
-                        ;;
+                    ('l') ztc:commander:shift _ztci_input _ztci_index L ;;
 
                     # ╶╶╶╶╶ <alt-t> (swap words around cursor) ╴╴╴╴╴
 
-                    ('t')
-                        local _left=''
-                        local _right=''
-                        local _lword=''
-                        local _rword=''
-
-                        ztc:words _input _index both _left _right _lword _rword
-                        ztc:shift _input _index T _left _right _lword _rword
-
-                        ztc[commander:input]=$_input
-                        ztc[commander:cursor]=${#_right}
-                        ;;
+                    ('t') ztc:commander:shift _ztci_input _ztci_index T ;;
 
                     # ╶╶╶╶╶ <alt-u> (uppercase word) ╴╴╴╴╴
 
-                    ('u')
-                        local _left=''
-                        local _right=''
-                        local _lword=''
-                        local _rword=''
-
-                        ztc:words _input _index both _left _right _lword _rword
-                        ztc:shift _input _index U _left _right _lword _rword
-
-                        ztc[commander:input]=$_input
-                        ztc[commander:cursor]=${#_right}
-                        ;;
+                    ('u') ztc:commander:shift _ztci_input _ztci_index U ;;
 
                     # ╶╶╶╶╶ ignore all other special keys ╴╴╴╴╴
 
@@ -619,20 +616,20 @@ function ztc:input { # detect user inputs + build commands
 
             # ╶╶╶╶╶ <ctrl-a> (move cursor to beginning) ╴╴╴╴╴
 
-            ($'\x1') ztc[commander:cursor]=${#_input} ;;
+            ($'\x1') ztc[commander:cursor]=${#_ztci_input} ;;
 
             # ╶╶╶╶╶ <ctrl-b> (move cursor left) ╴╴╴╴╴
 
-            ($'\x2') if (( _index > 0 )); then (( ztc[commander:cursor]++ )); fi ;;
+            ($'\x2') if (( _ztci_index > 0 )); then (( ztc[commander:cursor]++ )); fi ;;
 
             # ╶╶╶╶╶ <ctrl-d> (forward delete) ╴╴╴╴╴
 
             ($'\x4')
-                if (( ${#_input} == 0 )); then
+                if (( ${#_ztci_input} == 0 )); then
                     ztc:commander:leave
                 else
-                    if (( _index != ${#_input} )); then
-                        ztc[commander:input]=${_input:0:_index}${_input:$(( _index + 1 ))}
+                    if (( _ztci_index != ${#_ztci_input} )); then
+                        ztc[commander:input]=${_ztci_input:0:_ztci_index}${_ztci_input:$(( _ztci_index + 1 ))}
                         (( ztc[commander:cursor]-- ))
                     fi
                 fi ;;
@@ -643,7 +640,7 @@ function ztc:input { # detect user inputs + build commands
 
             # ╶╶╶╶╶ <ctrl-f> (move cursor) ╴╴╴╴╴
 
-            ($'\x6') if (( _cursor > 0 )); then (( ztc[commander:cursor]-- )); fi ;;
+            ($'\x6') if (( _ztci_cursor > 0 )); then (( ztc[commander:cursor]-- )); fi ;;
 
             # ╶╶╶╶╶ <ctrl-g> (<esc>) ╴╴╴╴╴
 
@@ -651,7 +648,7 @@ function ztc:input { # detect user inputs + build commands
 
             # ╶╶╶╶╶ <ctrl-h>/<backspace>/<delete> ╴╴╴╴╴
 
-            ($'\x8'|$'\b'|$'\x7f') if (( _index != 0 )); then ztc[commander:input]=${_input:0:$(( _index - 1 ))}${_input:_index}; fi ;;
+            ($'\x8'|$'\b'|$'\x7f') if (( _ztci_index != 0 )); then ztc[commander:input]=${_ztci_input:0:$(( _ztci_index - 1 ))}${_ztci_input:_ztci_index}; fi ;;
 
             # ╶╶╶╶╶ <ctrl-i> (<tab>) ╴╴╴╴╴
 
@@ -660,11 +657,17 @@ function ztc:input { # detect user inputs + build commands
             # ╶╶╶╶╶ <ctrl-j>/<ctrl-m>/<enter>/<return> ╴╴╴╴╴
 
             ($'\xA'|$'\xD'|$'\n'|$'\r')
-                if (( ${#_input} > 0 )); then
-                    local _parse=${(MS)_input##[[:graph:]]*[[:graph:]]} # trim whitespace
-                    if [[ -z $_parse ]]; then _parse=${(MS)_input##[[:graph:]]}; fi
+                if (( ${#_ztci_input} > 0 )); then
+                    local _ztci_history=()
+                    ztc:steal commander:history _ztci_history
 
-                    ztc:parse $_parse
+                    _ztci_history+=($_ztci_input)
+                    ztc:stash commander:history _ztci_history
+
+                    local _ztci_parse=${(MS)_ztci_input##[[:graph:]]*[[:graph:]]} # trim whitespace
+                    if [[ -z $_ztci_parse ]]; then _ztci_parse=${(MS)_ztci_input##[[:graph:]]}; fi
+
+                    ztc:parse $_ztci_parse
                 else
                     ztc:commander:leave
                 fi ;;
@@ -672,8 +675,8 @@ function ztc:input { # detect user inputs + build commands
             # ╶╶╶╶╶ <ctrl-k> (delete from cursor to end) ╴╴╴╴╴
 
             ($'\xB')
-                ztc[commander:yank]=${_input:_index}
-                ztc[commander:input]=${_input:0:_index}
+                ztc[commander:yank]=${_ztci_input:_ztci_index}
+                ztc[commander:input]=${_ztci_input:0:_ztci_index}
                 ztc[commander:cursor]=0
                 ;;
 
@@ -700,36 +703,36 @@ function ztc:input { # detect user inputs + build commands
 
             ($'\x11') ;; # pause
 
-            # ╶╶╶╶╶ <ctrl-r> (display/search history) ╴╴╴╴╴
+            # ╶╶╶╶╶ <ctrl-r> (search backward in history) ╴╴╴╴╴
 
-            ($'\x12') ;; # display/search history
+            ($'\x12') ;;
 
-            # ╶╶╶╶╶ <ctrl-s> (resume transmission) ╴╴╴╴╴
+            # ╶╶╶╶╶ <ctrl-s> (search forward in history) ╴╴╴╴╴
 
-            ($'\x13') ;; # resume
+            ($'\x13') ;;
 
             # ╶╶╶╶╶ <ctrl-t> (swap characters around cursor) ╴╴╴╴╴
 
             ($'\x14')
-                if (( _index > 0 )); then
-                    if (( _cursor == 0 )); then (( _index -= 1 )); fi
+                if (( _ztci_index > 0 )); then
+                    if (( _ztci_cursor == 0 )); then (( _ztci_index -= 1 )); fi
 
-                    local _left=${_input:0:$(( _index - 1 ))}
-                    local _right=${_input:$(( _index + 1 ))}
-                    local _a=${_input:$(( _index - 1 )):1}
-                    local _b=${_input:_index:1}
+                    local _ztci_left=${_ztci_input:0:$(( _ztci_index - 1 ))}
+                    local _ztci_right=${_ztci_input:$(( _ztci_index + 1 ))}
+                    local _ztci_a=${_ztci_input:$(( _ztci_index - 1 )):1}
+                    local _ztci_b=${_ztci_input:_ztci_index:1}
 
-                    ztc[commander:input]=$_left$_b$_a$_right
+                    ztc[commander:input]=$_ztci_left$_ztci_b$_ztci_a$_ztci_right
                 fi
 
-                if (( _cursor > 0 )); then (( ztc[commander:cursor]-- )); fi
+                if (( _ztci_cursor > 0 )); then (( ztc[commander:cursor]-- )); fi
                 ;;
 
             # ╶╶╶╶╶ <ctrl-u> (delete from beginning to cursor) ╴╴╴╴╴
 
             ($'\x15')
-                ztc[commander:yank]=${_input:0:_index}
-                ztc[commander:input]=${_input:_index}
+                ztc[commander:yank]=${_ztci_input:0:_ztci_index}
+                ztc[commander:input]=${_ztci_input:_ztci_index}
                 ;;
 
             # ╶╶╶╶╶ <ctrl-v> (literal insert) ╴╴╴╴╴
@@ -739,34 +742,32 @@ function ztc:input { # detect user inputs + build commands
             # ╶╶╶╶╶ <ctrl-w> (delete word) ╴╴╴╴╴
 
             ($'\x17')
-                if (( _index != 0 )); then
-                    local _left=''
-                    local _word=''
-                    ztc:words _input _index left _left _word
+                if (( _ztci_index != 0 )); then
+                    local _ztci_left=''
+                    local _ztci_word=''
+                    ztc:words _ztci_input _ztci_index left _ztci_left _ztci_word
 
-                    ztc[commander:yank]=$_word
-                    ztc[commander:input]=$_left${_input:_index}
+                    ztc[commander:yank]=$_ztci_word
+                    ztc[commander:input]=$_ztci_left${_ztci_input:_ztci_index}
                 fi ;;
 
             # ╶╶╶╶╶ <ctrl-x> (alternate between cursor and beginning) ╴╴╴╴╴
 
             ($'\x18')
-                if (( _index != 0 )); then
-                    ztc[commander:cursor:last]=$_cursor
-                    ztc[commander:cursor]=${#_input}
+                if (( _ztci_index != 0 )); then
+                    ztc[commander:cursor:last]=$_ztci_cursor
+                    ztc[commander:cursor]=${#_ztci_input}
                 else
                     ztc[commander:cursor]=$ztc[commander:cursor:last]
                 fi ;;
 
             # ╶╶╶╶╶ <ctrl-y> (paste) ╴╴╴╴╴
 
-            ($'\x19') ztc[commander:input]=${_input:0:_index}$ztc[commander:yank]${_input:_index} ;;
+            ($'\x19') ztc[commander:input]=${_ztci_input:0:_ztci_index}$ztc[commander:yank]${_ztci_input:_ztci_index} ;;
 
             # ╶╶╶╶╶ insert key at cursor index ╴╴╴╴╴
 
-            (*) integer _index=$(( ${#_input} - _cursor ))
-                ztc[commander:input]=${_input:0:_index}$_key${_input:_index}
-                ;;
+            (*) ztc[commander:input]=${_ztci_input:0:_ztci_index}$_ztci_key${_ztci_input:_ztci_index} ;;
 
         esac
 
@@ -775,7 +776,7 @@ function ztc:input { # detect user inputs + build commands
 
     else # input is a shortcut
 
-        case $_key in
+        case $_ztci_key in
             ($'\e')         ztc:commander:clear ;;
             (q|Q)           ztc:clean ;;
             (:|$'\n'|$'\r') ztc:commander:enter ;;
@@ -790,29 +791,29 @@ function ztc:input { # detect user inputs + build commands
 # └╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶┘
 
 function ztc:parse { # delegate command to correct parser
-    local _input=(${(As: :)1})
-    local _command=${(L)_input[1]//\\/\\\\}
+    local _ztcps_input=(${(As: :)1})
+    local _ztcps_command=${(L)_ztcps_input[1]//\\/\\\\}
 
-    local -U _commands=()
-    ztc:steal :commands _commands
+    local -U _ztcps_commands=()
+    ztc:steal :commands _ztcps_commands
 
-    case $_command in
+    case $_ztcps_command in
         (q|quit|exit)
             ztc:clean
             ;;
         (*)
-            if (( _commands[(Ie)$_command] )); then
-                ztc:parse:$_command ${_input:1}
+            if (( _ztcps_commands[(Ie)$_ztcps_command] )); then
+                ztc:parse:$_ztcps_command ${_ztcps_input:1}
                 ztc:commander:leave
             else
-                ztc:commander:leave "@i Unknown command: ${_command//@/@@} @r"
+                ztc:commander:leave "@i Unknown command: ${_ztcps_command//@/@@} @r"
             fi ;;
     esac
 }
 
 function ztc:parse:date {
-    local _format=${(j: :)@}
-    ztc[:date:format]=${_format:-"%a %b %d %p"}
+    local _ztcpsd_format=${(j: :)@}
+    ztc[:date:format]=${_ztcpsd_format:-"%a %b %d %p"}
     ztc:cycle date
 }
 
@@ -839,54 +840,54 @@ function ztc:order:face:digital {
 }
 
 function ztc:alter:face:digital {
-    local _time=''
-    strftime -s _time "%l:%M:%S"
+    local _ztcafd_time=''
+    strftime -s _ztcafd_time "%l:%M:%S"
 
-    local _mask=()
-    local _staged=()
+    local _ztcafd_mask=()
+    local _ztcafd_staged=()
 
 
     # ───── create mask ─────
 
-    for _character in ${(s::)_time}; do
-        case $_character in
-            (0) _mask=(111 101 101 101 111) ;;
-            (1) _mask=(001 001 001 001 001) ;;
-            (2) _mask=(111 001 111 100 111) ;;
-            (3) _mask=(111 001 111 001 111) ;;
-            (4) _mask=(101 101 111 001 001) ;;
-            (5) _mask=(111 100 111 001 111) ;;
-            (6) _mask=(111 100 111 101 111) ;;
-            (7) _mask=(111 001 001 001 001) ;;
-            (8) _mask=(111 101 111 101 111) ;;
-            (9) _mask=(111 101 111 001 111) ;;
-            (:) _mask=( 0   1   0   1   0 ) ;;
+    for _ztcafd_character in ${(s::)_ztcafd_time}; do
+        case $_ztcafd_character in
+            (0) _ztcafd_mask=(111 101 101 101 111) ;;
+            (1) _ztcafd_mask=(001 001 001 001 001) ;;
+            (2) _ztcafd_mask=(111 001 111 100 111) ;;
+            (3) _ztcafd_mask=(111 001 111 001 111) ;;
+            (4) _ztcafd_mask=(101 101 111 001 001) ;;
+            (5) _ztcafd_mask=(111 100 111 001 111) ;;
+            (6) _ztcafd_mask=(111 100 111 101 111) ;;
+            (7) _ztcafd_mask=(111 001 001 001 001) ;;
+            (8) _ztcafd_mask=(111 101 111 101 111) ;;
+            (9) _ztcafd_mask=(111 101 111 001 111) ;;
+            (:) _ztcafd_mask=( 0   1   0   1   0 ) ;;
         esac
 
-        _staged+=(${(j:@n:)_mask})
+        _ztcafd_staged+=(${(j:@n:)_ztcafd_mask})
     done
 
 
     # ───── set mask key ─────
 
-    local -U _key=()
+    local -U _ztcafd_key=()
 
-    _key+=('0#@r  ')
-    _key+=('1#@i  ')
-    _key+=('.#@r ')
+    _ztcafd_key+=('0#@r  ')
+    _ztcafd_key+=('1#@i  ')
+    _ztcafd_key+=('.#@r ')
 
-    ztc:stash face:digital:data:key _key
+    ztc:stash face:digital:data:key _ztcafd_key
 
 
     # ───── interleave + flatten (with padding) ─────
 
-    ztc:weave _staged
-    for _i in {1..${#_staged}}; do _staged[$_i]=${_staged[$_i]//@n/.}; done
+    ztc:weave _ztcafd_staged
+    for _ztcafd_i in {1..${#_ztcafd_staged}}; do _ztcafd_staged[$_ztcafd_i]=${_ztcafd_staged[$_ztcafd_i]//@n/.}; done
 
 
     # ───── save ─────
 
-    ztc:stash face:digital:data _staged
+    ztc:stash face:digital:data _ztcafd_staged
 }
 
 
@@ -902,10 +903,10 @@ function ztc:order:date {
 }
 
 function ztc:alter:date {
-    local _date=''
-    strftime -s _date ${ztc[:date:format]//\%n/@n} # capture newlines
+    local _ztcad_date=''
+    strftime -s _ztcad_date ${ztc[:date:format]//\%n/@n} # capture newlines
 
-    ztc:stash date:data _date
+    ztc:stash date:data _ztcad_date
 }
 
 
@@ -914,80 +915,90 @@ function ztc:alter:date {
 # └─────────────────┘
 
 function ztc:order:commander {
-    # space declaration
+
+    # ───── space declaration ─────
+
     ztc[commander:y]=$ztc[vh]
     ztc[commander:x]=0
     ztc[commander:h]=1
     ztc[commander:w]=$ztc[vw]
 
-    # extended component properties
+
+    # ───── extended properties ─────
+
     ztc[commander:overlay]=1
 
-    # commander properties
+
+    # ───── custom properties ─────
+
     ztc[commander:active]=${ztc[commander:active]:-0}
 
     ztc[commander:prefix]=${ztc[commander:prefix]:-:}
     ztc[commander:status]=${ztc[commander:status]:-}
     ztc[commander:input]=${ztc[commander:input]:-}
 
+    ztc[commander:history]=${ztc[commander:history]:-}
+    ztc[commander:history:index]=${ztc[commander:history:index]:-0}
+
     ztc[commander:yank]=${ztc[commander:yank]:-}
     ztc[commander:cursor]=${ztc[commander:cursor]:-0}
     ztc[commander:cursor:last]=${ztc[commander:cursor:last]:-0}
+
 }
 
 function ztc:alter:commander {
 
     # ───── import ─────
 
-    local _input=$ztc[commander:input]
-    integer _cursor=$ztc[commander:cursor]
+    local _ztcac_input=$ztc[commander:input]
+    integer _ztcac_cursor=$ztc[commander:cursor]
 
 
     # ───── truncate overflows ─────
 
-    integer _index=$(( ${#_input} - _cursor ))
-    integer _bound=$(( ztc[commander:w] - ${#ztc[commander:prefix]} ))
+    integer _ztcac_index=$(( ${#_ztcac_input} - _ztcac_cursor ))
+    integer _ztcac_bound=$(( ztc[commander:w] - ${#ztc[commander:prefix]} ))
 
-    if (( ${#_input} > _bound )); then
+    if (( ${#_ztcac_input} > _ztcac_bound )); then
 
         # ╶╶╶╶╶ split input at cursor ╴╴╴╴╴
 
-        local _left=${_input:0:_index}
-        local _right=${_input:_index}
+        local _ztcac_left=${_ztcac_input:0:_ztcac_index}
+        local _ztcac_right=${_ztcac_input:_ztcac_index}
 
         # ╶╶╶╶╶ determine truncate order + trim to fit ╴╴╴╴╴
 
-        if (( ${#_left} > ${#_right} )); then
-            if (( ${#_right} > _bound / 2 )); then _right=${_right:0:$(( (_bound / 2) - 3 ))}...; fi
-            if (( ${#_left} + ${#_right} > _bound )); then _left=...${_left:$(( -_bound + ${#_right} + 3 ))}; fi
+        if (( ${#_ztcac_left} > ${#_ztcac_right} )); then
+            if (( ${#_ztcac_right} > _ztcac_bound / 2 )); then _ztcac_right=${_ztcac_right:0:$(( (_ztcac_bound / 2) - 3 ))}...; fi
+            if (( ${#_ztcac_left} + ${#_ztcac_right} > _ztcac_bound )); then _ztcac_left=...${_ztcac_left:$(( -_ztcac_bound + ${#_ztcac_right} + 3 ))}; fi
         else
-            if (( ${#_left} > _bound / 2 )); then _left=...${_left:$(( -(_bound / 2) + 3 ))}; fi
-            if (( ${#_right} + ${#_left} > _bound )); then _right=${_right:0:$(( _bound - ${#_left} - 3 ))}...; fi
+            if (( ${#_ztcac_left} > _ztcac_bound / 2 )); then _ztcac_left=...${_ztcac_left:$(( -(_ztcac_bound / 2) + 3 ))}; fi
+            if (( ${#_ztcac_right} + ${#_ztcac_left} > _ztcac_bound )); then _ztcac_right=${_ztcac_right:0:$(( _ztcac_bound - ${#_ztcac_left} - 3 ))}...; fi
         fi
 
         # ╶╶╶╶╶ reassemble + adjust cursor ╴╴╴╴╴
 
-        _input="$_left$_right"
-        _cursor=${#_right}
+        _ztcac_input="$_ztcac_left$_ztcac_right"
+        _ztcac_cursor=${#_ztcac_right}
 
     fi
 
 
     # ───── position cursor ─────
 
-    local _position
+    local _ztcac_position
 
-    if (( _cursor > 0 )); then _position="$ZTC_CSI${_cursor}D"; fi
+    if (( _ztcac_cursor > 0 )); then _ztcac_position="$ZTC_CSI${_ztcac_cursor}D"; fi
 
 
     # ───── export ─────
 
-    local _data=()
+    local _ztcac_data=()
 
-    if (( ztc[commander:active] )); then _data=${ztc[commander:prefix]}${_input//@/@@}$_position$ZTC_CURSOR_SHOW
-    else _data=$ztc[commander:status]$ZTC_CURSOR_HIDE; fi
+    if (( ztc[commander:active] )); then _ztcac_data=${ztc[commander:prefix]}${_ztcac_input//@/@@}$_ztcac_position$ZTC_CURSOR_SHOW
+    else _ztcac_data=$ztc[commander:status]$ZTC_CURSOR_HIDE; fi
 
-    ztc:stash commander:data _data
+    ztc:stash commander:data _ztcac_data
 
 }
 
@@ -1007,31 +1018,31 @@ function ztc:stash { # escape flares + flatten array for storage
 
     # ───── import ─────
 
-    local _pouch=(${(AP)2})
+    local _ztcsth_pouch=(${(AP)2})
 
 
     # ───── build stash ─────
 
-    local _stash=()
+    local _ztcsth_stash=()
 
-    for _jewel in $_pouch; do
+    for _ztcsth_jewel in $_ztcsth_pouch; do
 
         # ╶╶╶╶╶ escape `@@` + split by `@n` ╴╴╴╴╴
 
-        local _shiny=(${(As:@n:)_jewel//@@/@\(@\)})
+        local _ztcsth_shiny=(${(As:@n:)_ztcsth_jewel//@@/@\(@\)})
 
         # ╶╶╶╶╶ escape `@` + add to stash ╴╴╴╴╴
 
-        for _i in {1..${#_shiny}}; do _shiny[$_i]=${_shiny[$_i]//@/@@}; done
+        for _ztcsth_i in {1..${#_ztcsth_shiny}}; do _ztcsth_shiny[$_ztcsth_i]=${_ztcsth_shiny[$_ztcsth_i]//@/@@}; done
 
-        _stash+=($_shiny)
+        _ztcsth_stash+=($_ztcsth_shiny)
 
     done
 
 
     # ───── export ─────
 
-    ztc[$1]=${(j:@n:)_stash//@@\(@@\)/@\(@\)} # reduce `@@(@@)` into `@(@)`
+    ztc[$1]=${(j:@n:)_ztcsth_stash//@@\(@@\)/@\(@\)} # reduce `@@(@@)` into `@(@)`
 
 }
 
@@ -1039,41 +1050,41 @@ function ztc:steal { # retrieve flattened array + undo flare escapement
 
     # ───── import ─────
 
-    local _stash=(${(As:@@:)ztc[$1]})
+    local _ztcstl_stash=(${(As:@@:)ztc[$1]})
 
 
     # ───── steal stash ─────
 
-    local _theft=()
-    local _prior=''
+    local _ztcstl_theft=()
+    local _ztcstl_prior=''
 
-    if [[ ${ztc[$1]:0:2} == '@@' ]]; then _prior='@ '; fi # preserve leading `@`
+    if [[ ${ztc[$1]:0:2} == '@@' ]]; then _ztcstl_prior='@ '; fi # preserve leading `@`
 
-    for _jewel in $_stash; do
+    for _ztcstl_jewel in $_ztcstl_stash; do
 
         # ╶╶╶╶╶ split by `@n` ╴╴╴╴╴
 
-        local _shiny=(${(As:@n:)_jewel})
+        local _ztcstl_shiny=(${(As:@n:)_ztcstl_jewel})
 
         # ╶╶╶╶╶ insert escaped `@` ╴╴╴╴╴
 
-        _prior=${_prior:+${_prior}@}
-        _shiny[1]=${_prior/#@ }$_shiny[1] # compress `@ @` into `@`
+        _ztcstl_prior=${_ztcstl_prior:+${_ztcstl_prior}@}
+        _ztcstl_shiny[1]=${_ztcstl_prior/#@ }$_ztcstl_shiny[1] # compress `@ @` into `@`
 
         # ╶╶╶╶╶ prep for next jewel + add to theft ╴╴╴╴╴
 
-        _prior=$_shiny[-1]
-        shift -p _shiny
+        _ztcstl_prior=$_ztcstl_shiny[-1]
+        shift -p _ztcstl_shiny
 
-        _theft+=($_shiny)
+        _ztcstl_theft+=($_ztcstl_shiny)
 
     done
 
 
     # ───── export ─────
 
-    _theft+=($_prior)
-    : ${(AP)2::=$_theft}
+    _ztcstl_theft+=($_ztcstl_prior)
+    : ${(AP)2::=$_ztcstl_theft}
 
 }
 
@@ -1086,38 +1097,38 @@ function ztc:weave { # ((1 1 1) (2 2 2) (3 3 3)) -> ((1 2 3) (1 2 3) (1 2 3))
 
     # ───── import ─────
 
-    local _array=(${(AP)1})
+    local _ztcwv_array=(${(AP)1})
 
 
     # ───── determine max sub-length ─────
 
-    integer _length=0
+    integer _ztcwv_length=0
 
-    for _item in $_array; do
-        local _sub=(${(As:@n:)_item})
-        if (( $#_sub > _length )); then _length=${#_sub}; fi
+    for _ztcwv_item in $_ztcwv_array; do
+        local _ztcwv_sub=(${(As:@n:)_ztcwv_item})
+        if (( $#_ztcwv_sub > _ztcwv_length )); then _ztcwv_length=${#_ztcwv_sub}; fi
     done
 
 
     # ───── weave ─────
 
-    local _weaved=()
+    local _ztcwv_weaved=()
 
-    for _i in {1..$_length}; do
-        local _select=()
+    for _ztcwv_i in {1..$_ztcwv_length}; do
+        local _ztcwv_select=()
 
-        for _item in $_array; do
-            local _sub=(${(As:@n:)_item})
-            _select+=($_sub[$_i])
+        for _ztcwv_item in $_ztcwv_array; do
+            local _ztcwv_sub=(${(As:@n:)_ztcwv_item})
+            _ztcwv_select+=($_ztcwv_sub[$_ztcwv_i])
         done
 
-        _weaved+=(${(j:@n:)_select})
+        _ztcwv_weaved+=(${(j:@n:)_ztcwv_select})
     done
 
 
     # ───── export ─────
 
-    : ${(AP)1::=$_weaved}
+    : ${(AP)1::=$_ztcwv_weaved}
 
 }
 
@@ -1130,46 +1141,52 @@ function ztc:words { # get closest word boundaries (ztc:words _input _index both
 
     # ───── import ─────
 
-    local _in=${(P)1}
-    local _i=${(P)2}
+    local _ztcw_input=${(P)1}
+    local _ztcw_index=${(P)2}
 
 
-    # ───── split left/right + get closest word boundaries ─────
+    # ───── get closest word boundaries ─────
 
-    local _l=${(*)${_in:0:_i}/%[[:space:]]#} # trim trailing spaces in left
-    local _r=${(*)${_in:_i}/#[[:space:]]#}   # trim leading spaces in right
+    # ╶╶╶╶╶ left ╴╴╴╴╴
 
-    local _lw=${(MS)_l##[[:graph:]]*[[:graph:]]} # trim all whitespace in left
-    local _rw=${(MS)_r##[[:graph:]]*[[:graph:]]} # trim all whitespace in right
-    if [[ -z $_lw ]]; then _lw=${(MS)_l##[[:graph:]]}; fi
-    if [[ -z $_rw ]]; then _rw=${(MS)_r##[[:graph:]]}; fi
+    local _ztcw_left=${(*)${_ztcw_input:0:_ztcw_index}/%[[:space:]]#} # trim trailing spaces in left
+    local _ztcw_word_left=${(MS)_ztcw_left##[[:graph:]]*[[:graph:]]}  # trim all whitespace in left
+    if [[ -z $_ztcw_word_left ]]; then _ztcw_word_left=${(MS)_ztcw_left##[[:graph:]]}; fi
 
-    if [[ ! $_l =~ ' ' ]]; then _l=''
-    else _l="${_l%[[:space:]]*} "; fi  # remove last word in left
+    if [[ ! $_ztcw_left =~ ' ' ]]; then _ztcw_left=''
+    else _ztcw_left="${_ztcw_left%[[:space:]]*} "; fi  # remove last word in left
 
-    if [[ ! $_r =~ ' ' ]]; then _r=''
-    else _r=" ${_r#*[[:space:]]}"; fi # remove first word in right
+    # ╶╶╶╶╶ right ╴╴╴╴╴
 
-    _lw=${_lw##*[[:space:]]} # select last word in left
-    _rw=${_rw%%[[:space:]]*} # select first word in right
+    local _ztcw_right=${(*)${_ztcw_input:_ztcw_index}/#[[:space:]]#}   # trim leading spaces in right
+    local _ztcw_word_right=${(MS)_ztcw_right##[[:graph:]]*[[:graph:]]} # trim all whitespace in right
+    if [[ -z $_ztcw_word_right ]]; then _ztcw_word_right=${(MS)_ztcw_right##[[:graph:]]}; fi
+
+    if [[ ! $_ztcw_right =~ ' ' ]]; then _ztcw_right=''
+    else _ztcw_right=" ${_ztcw_right#*[[:space:]]}"; fi # remove first word in right
+
+    # ╶╶╶╶╶ select words ╴╴╴╴╴
+
+    _ztcw_word_left=${_ztcw_word_left##*[[:space:]]}   # select last word in left
+    _ztcw_word_right=${_ztcw_word_right%%[[:space:]]*} # select first word in right
 
 
     # ───── export ─────
 
     case $3 in
         (left)
-            if [[ -n $4 ]]; then : ${(P)4::=$_l}; fi
-            if [[ -n $5 ]]; then : ${(P)5::=$_lw}; fi
+            if [[ -n $4 ]]; then : ${(P)4::=$_ztcw_left}; fi
+            if [[ -n $5 ]]; then : ${(P)5::=$_ztcw_word_left}; fi
             ;;
         (right)
-            if [[ -n $4 ]]; then : ${(P)4::=$_r}; fi
-            if [[ -n $5 ]]; then : ${(P)5::=$_rw}; fi
+            if [[ -n $4 ]]; then : ${(P)4::=$_ztcw_right}; fi
+            if [[ -n $5 ]]; then : ${(P)5::=$_ztcw_word_right}; fi
             ;;
         (both)
-            if [[ -n $4 ]]; then : ${(P)4::=$_l}; fi
-            if [[ -n $5 ]]; then : ${(P)5::=$_r}; fi
-            if [[ -n $6 ]]; then : ${(P)6::=$_lw}; fi
-            if [[ -n $7 ]]; then : ${(P)7::=$_rw}; fi
+            if [[ -n $4 ]]; then : ${(P)4::=$_ztcw_left}; fi
+            if [[ -n $5 ]]; then : ${(P)5::=$_ztcw_right}; fi
+            if [[ -n $6 ]]; then : ${(P)6::=$_ztcw_word_left}; fi
+            if [[ -n $7 ]]; then : ${(P)7::=$_ztcw_word_right}; fi
             ;;
     esac
 
@@ -1179,79 +1196,79 @@ function ztc:shift { # transform word at boundary (ztc:shift _input _index (T|C|
 
     # ───── import ─────
 
-    local _in=${(P)1}
-    local _i=${(P)2}
-    local _l=${(P)4}
-    local _r=${(P)5}
-    local _lw=${(P)6}
-    local _rw=${(P)7}
+    local _ztcws_input=${(P)1}
+    local _ztcws_index=${(P)2}
+    local _ztcws_left=${(P)4}
+    local _ztcws_right=${(P)5}
+    local _ztcws_word_left=${(P)6}
+    local _ztcws_word_right=${(P)7}
 
-    local _shift=$3
+    local _ztcws_shift=$3
 
 
     # ───── get word(s) ─────
 
-    local _lb=$(( _i - ${#_lw} ))
-    local _rb=$(( ${#_lw} + ${#_rw} ))
+    local _ztcws_bound_left=$(( _ztcws_index - ${#_ztcws_word_left} ))
+    local _ztcws_bound_right=$(( ${#_ztcws_word_left} + ${#_ztcws_word_right} ))
 
-    if [[ $_shift == 'T' && "$_lw$_rw" == "${_in:_lb:_rb}" ]]; then # cursor is inside word
+    if [[ $_ztcws_shift == 'T' && "$_ztcws_word_left$_ztcws_word_right" == "${_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}" ]]; then # cursor is inside word
 
-        _rw=$_lw$_rw
+        _ztcws_word_right=$_ztcws_word_left$_ztcws_word_right
 
-        _l=${(*)_l/%[[:space:]]#} # retrim trailing spaces
-        _lw=${_l##*[[:space:]]}   # select new last word
+        _ztcws_left=${(*)_ztcws_left/%[[:space:]]#}   # retrim trailing spaces
+        _ztcws_word_left=${_ztcws_left##*[[:space:]]} # select new last word
 
-        if [[ ! $_l =~ ' ' ]]; then _l=''
-        else _l="${_l%[[:space:]]*} "; fi # remove new last word
+        if [[ ! $_ztcws_left =~ ' ' ]]; then _ztcws_left=''
+        else _ztcws_left="${_ztcws_left%[[:space:]]*} "; fi # remove new last word
 
-    elif [[ $_shift != 'T' && "$_lw$_rw" != "${_in:_lb:_rb}" ]]; then # cursor is between words
+    elif [[ $_ztcws_shift != 'T' && "$_ztcws_word_left$_ztcws_word_right" != "${_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}" ]]; then # cursor is between words
 
-        _lb=$_i
-        _rb=$(( ${#_rw} + 1 ))
+        _ztcws_bound_left=$_ztcws_index
+        _ztcws_bound_right=$(( ${#_ztcws_word_right} + 1 ))
 
-        _l="$_l$_lw " # reattach
+        _ztcws_left="$_ztcws_left$_ztcws_word_left " # reattach
 
     fi
 
 
     # ───── shift word(s) + export ─────
 
-    local _w=''
+    local _ztcws_word=''
 
-    case $_shift in
+    case $_ztcws_shift in
 
         # ╶╶╶╶╶ transpose ╴╴╴╴╴
 
-        (T) if [[ -n $_lw ]]; then _rw="$_rw "; fi
-            _w=$_rw$_lw
+        (T) if [[ -n $_ztcws_word_left ]]; then _ztcws_word_right="$_ztcws_word_right "; fi
+            _ztcws_word=$_ztcws_word_right$_ztcws_word_left
             ;;
 
         # ╶╶╶╶╶ capitalize ╴╴╴╴╴
 
-        (C) _w=${(MS)${(C)_in:_lb:_rb}##[[:graph:]]*[[:graph:]]} # trim whitespace
-            if [[ -z $_w ]]; then _word=${(MS)${(C)_in:_lb:_rb}##[[:graph:]]}; fi
+        (C) _ztcws_word=${(MS)${(C)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]*[[:graph:]]} # trim whitespace
+            if [[ -z $_ztcws_word ]]; then _ztcws_word=${(MS)${(C)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]}; fi
             ;;
 
         # ╶╶╶╶╶ lowercase ╴╴╴╴╴
 
-        (L) _w=${(MS)${(L)_in:_lb:_rb}##[[:graph:]]*[[:graph:]]} # trim whitespace
-            if [[ -z $_w ]]; then _word=${(MS)${(L)_in:_lb:_rb}##[[:graph:]]}; fi
+        (L) _ztcws_word=${(MS)${(L)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]*[[:graph:]]} # trim whitespace
+            if [[ -z $_ztcws_word ]]; then _ztcws_word=${(MS)${(L)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]}; fi
             ;;
 
         # ╶╶╶╶╶ uppercase ╴╴╴╴╴
 
-        (U) _w=${(MS)${(U)_in:_lb:_rb}##[[:graph:]]*[[:graph:]]} # trim whitespace
-            if [[ -z $_w ]]; then _word=${(MS)${(U)_in:_lb:_rb}##[[:graph:]]}; fi
+        (U) _ztcws_word=${(MS)${(U)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]*[[:graph:]]} # trim whitespace
+            if [[ -z $_ztcws_word ]]; then _ztcws_word=${(MS)${(U)_ztcws_input:_ztcws_bound_left:_ztcws_bound_right}##[[:graph:]]}; fi
             ;;
 
     esac
 
-    : ${(P)4::=$_l}
-    : ${(P)5::=$_r}
-    : ${(P)6::=$_lw}
-    : ${(P)7::=$_rw}
+    : ${(P)4::=$_ztcws_left}
+    : ${(P)5::=$_ztcws_right}
+    : ${(P)6::=$_ztcws_word_left}
+    : ${(P)7::=$_ztcws_word_right}
 
-    : ${(P)1::=$_l$_w$_r}
+    : ${(P)1::=$_ztcws_left$_ztcws_word$_ztcws_right}
 
 }
 


### PR DESCRIPTION
## Unix Shortcuts

This PR adds support for the majority of unix terminal shortcuts, itemized below.

Additionally, this also adds history and navigation to the command bar, the implementation of which necessitated namespacing all private variables. This simulataneously makes the codebase harder and easier to read: harder because of the cognitive overhead of reading the namespaces, but easier because each variable can be descriptive without worrying about collisions within nested function calls.

In practice, I find the namespacing tends to get automatically filtered out by the brain after a while.

<details>
<summary>Unix Terminal Shortcuts</summary>

Key | Description | Alias
--- | :--- | :---
:white_check_mark: `<ctrl-a>` | Move the cursor to the beginning
:white_check_mark: `<ctrl-b>` | Move the cursor left | `<left>`
:white_check_mark: `<ctrl-c>` | Force-quit zshclock with status code `1`
:white_check_mark: `<ctrl-d>` | Forward delete the character above the cursor <br> Close the command bar if empty<sup>ztc</sup>
:white_check_mark: `<ctrl-e>` | Move the cursor to the end
:white_check_mark: `<ctrl-f>` | Move the cursor right | `<right>`
:white_check_mark: `<ctrl-g>`<sup>ztc</sup> | Abort the input | `<esc>`
:white_check_mark: `<ctrl-h>` | Delete the character under the cursor | `<backspace>`
:x: `<ctrl-i>`<sup>ztc</sup> | Autocomplete the command | `<tab>`
:white_check_mark: `<ctrl-j>`<sup>ztc</sup> | Line feed/newline _(handled like `<enter>`)_
:white_check_mark: `<ctrl-k>`<sup>ztc</sup> | Forward delete from the cursor to the end
:white_check_mark: `<ctrl-l>`<sup>ztc</sup> | Clear screen _(empties the input)_
:white_check_mark: `<ctrl-m>`<sup>ztc</sup> | Submit the input <br> Open the command bar if closed <br> Close the command bar if empty | `<enter>`
:white_check_mark: `<ctrl-n>`<sup>ztc</sup> | Next line in history | `<down>`
:white_check_mark: `<ctrl-o>`<sup>ztc</sup> | Submit the input + display next line in history
:white_check_mark: `<ctrl-p>`<sup>ztc</sup> | Previous line in history | `<up>`
:white_check_mark: `<ctrl-q>`<sup>_disabled_</sup> | Literal insert
:x: `<ctrl-r>`<sup>ztc</sup> | Search backward in history
:x: `<ctrl-s>`<sup>ztc</sup> | Search forward in history
:white_check_mark: `<ctrl-t>`<sup>ztc</sup> | Swap two characters around the cursor
:white_check_mark: `<ctrl-u>` | Delete from the cursor to the beginning
:white_check_mark: `<ctrl-v>`<sup>_disabled_</sup> | Literal insert
:white_check_mark: `<ctrl-w>`<sup>ztc</sup> | Delete from the cursor to the beginning of current word | `<alt-backspace>`
:white_check_mark: `<ctrl-x>`<sup>ztc</sup> | Alternate the cursor between its current position and the beginning
:white_check_mark: `<ctrl-y>`<sup>ztc</sup> | Paste deleted text
:o: `<ctrl-z>`<sup>ztc</sup> | Suspend zshclock
|||
:white_check_mark: `<alt-b>`<sup>ztc</sup> | Move the cursor one word left | `<alt-left>`
:white_check_mark: `<alt-c>`<sup>ztc</sup> | Capitalize the current word
:white_check_mark: `<alt-d>`<sup>ztc</sup> | Forward delete from the cursor to the end of the current word
:white_check_mark: `<alt-f>`<sup>ztc</sup> | Move the cursor one word right | `<alt-right>`
:white_check_mark: `<alt-l>`<sup>ztc</sup> | Lowercase the current word
:white_check_mark: `<alt-n>`<sup>ztc</sup> | Next line in history based on the current input | `<alt-down>`
:white_check_mark: `<alt-p>`<sup>ztc</sup> | Previous line in history based on the current input | `<alt-up>`
:white_check_mark: `<alt-t>`<sup>ztc</sup> | Swap two words around the cursor
:white_check_mark: `<alt-u>`<sup>ztc</sup> | Uppercase the current word
:white_check_mark: `<alt-shift-,>`<sup>ztc</sup> | Retrieve the first line in history
:white_check_mark: `<alt-shift-.>`<sup>ztc</sup> | Retrieve the last line in history

_Shortcut behaviors follow the actions described in `man bash` as closely as possible_

</details>

### Known Issues

- When sweeping through the history, changes to the current line are not preserved, so navigating away and back restores the line as originally saved. This is in contrast to how zsh normally handles history, which is to preserve any changes to any line in history, and only reset (or update) those changes upon submission.

- This also means that when filtering the history, changes to an entry do not allow re-filtering under those changes. The filter only gets reset/changed when the command bar closes (or clears with `<ctrl-l>`), or if the original filter is returned to and updated. This can get a little tedious to work with, but changing this behavior likely requires a complete rewrite of the history code, and there are more pressing things that need working on.

- When submitting with `<ctrl-o>`, if the history value was altered before submission, then the original value is not removed from history. This behavior might actually be a feature, but it feels inconsistent with how zsh handles changes to history, so I'm listing it here.